### PR TITLE
Add and configure Clearance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 ruby "2.4.0"
 
 gem "autoprefixer-rails"
+gem "clearance"
 gem "delayed_job_active_record"
 gem "flutie"
 gem "honeybadger"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -44,6 +44,7 @@ GEM
     autoprefixer-rails (6.7.7)
       execjs
     awesome_print (1.7.0)
+    bcrypt (3.1.11)
     bitters (1.5.0)
       bourbon (~> 5.0.0.beta.7)
       sass (~> 3.4)
@@ -69,6 +70,10 @@ GEM
     capybara-webkit (1.13.0)
       capybara (>= 2.3.0, < 2.13.0)
       json
+    clearance (1.16.0)
+      bcrypt
+      email_validator (~> 1.4)
+      rails (>= 3.1)
     coderay (1.1.1)
     concurrent-ruby (1.0.5)
     crack (0.4.3)
@@ -86,6 +91,8 @@ GEM
     dotenv-rails (2.2.0)
       dotenv (= 2.2.0)
       railties (>= 3.2, < 5.1)
+    email_validator (1.6.0)
+      activemodel
     erubis (2.7.0)
     execjs (2.7.0)
     factory_girl (4.8.0)
@@ -275,6 +282,7 @@ DEPENDENCIES
   bullet
   bundler-audit (>= 0.5.0)
   capybara-webkit
+  clearance
   database_cleaner
   delayed_job_active_record
   dotenv-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
+  include Clearance::Controller
   protect_from_forgery with: :exception
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,3 @@
+class User < ApplicationRecord
+  include Clearance::User
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -18,5 +18,19 @@
   <%= yield %>
   <%= render "javascript" %>
   <%= render "css_overrides" %>
+
+  <% if signed_in? %>
+    Signed in as: <%= current_user.email %>
+    <%= button_to 'Sign out', sign_out_path, method: :delete %>
+  <% else %>
+    <%= link_to 'Sign in', sign_in_path %>
+  <% end %>
+
+  <div id="flash">
+    <% flash.each do |key, value| %>
+      <div class="flash <%= key %>"><%= value %></div>
+    <% end %>
+  </div>
+
 </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,9 +21,9 @@
 
   <% if signed_in? %>
     Signed in as: <%= current_user.email %>
-    <%= button_to 'Sign out', sign_out_path, method: :delete %>
+    <%= button_to t('layouts.application.sign_out'), sign_out_path, method: :delete %>
   <% else %>
-    <%= link_to 'Sign in', sign_in_path %>
+    <%= link_to t('layouts.application.sign_in'), sign_in_path %>
   <% end %>
 
   <div id="flash">

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -14,6 +14,6 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
   config.action_view.raise_on_missing_translations = true
   config.assets.raise_runtime_errors = true
-  config.action_mailer.default_url_options = { host: "www.example.com" }
+  config.action_mailer.default_url_options = { host: 'localhost:3000' }
   config.active_job.queue_adapter = :inline
 end

--- a/config/initializers/clearance.rb
+++ b/config/initializers/clearance.rb
@@ -1,0 +1,4 @@
+Clearance.configure do |config|
+  config.mailer_sender = "reply@example.com"
+  config.rotate_csrf_on_sign_in = true
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,6 +21,11 @@ en:
     validations:
       required: "can\'t be blank"
 
+  layouts:
+    application:
+      sign_in: "Sign in"
+      sign_out: "Sign out"
+
   date:
     formats:
       default:

--- a/db/migrate/20170327174027_create_users.rb
+++ b/db/migrate/20170327174027_create_users.rb
@@ -1,0 +1,14 @@
+class CreateUsers < ActiveRecord::Migration[5.0]
+  def change
+    create_table :users do |t|
+      t.timestamps null: false
+      t.string :email, null: false
+      t.string :encrypted_password, limit: 128, null: false
+      t.string :confirmation_token, limit: 128
+      t.string :remember_token, limit: 128, null: false
+    end
+
+    add_index :users, :email
+    add_index :users, :remember_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170320195445) do
+ActiveRecord::Schema.define(version: 20170327174027) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -36,6 +36,17 @@ ActiveRecord::Schema.define(version: 20170320195445) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["priority", "run_at"], name: "delayed_jobs_priority", using: :btree
+  end
+
+  create_table "users", force: :cascade do |t|
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+    t.string   "email",                          null: false
+    t.string   "encrypted_password", limit: 128, null: false
+    t.string   "confirmation_token", limit: 128
+    t.string   "remember_token",     limit: 128, null: false
+    t.index ["email"], name: "index_users_on_email", using: :btree
+    t.index ["remember_token"], name: "index_users_on_remember_token", using: :btree
   end
 
 end

--- a/spec/factories/clearance.rb
+++ b/spec/factories/clearance.rb
@@ -1,0 +1,10 @@
+FactoryGirl.define do
+  sequence :email do |n|
+    "user#{n}@example.com"
+  end
+
+  factory :user do
+    email
+    password "password"
+  end
+end

--- a/spec/features/clearance/user_signs_out_spec.rb
+++ b/spec/features/clearance/user_signs_out_spec.rb
@@ -1,0 +1,11 @@
+require "rails_helper"
+require "support/features/clearance_helpers"
+
+RSpec.feature "User signs out" do
+  scenario "signs out" do
+    sign_in
+    sign_out
+
+    expect_user_to_be_signed_out
+  end
+end

--- a/spec/features/clearance/visitor_resets_password_spec.rb
+++ b/spec/features/clearance/visitor_resets_password_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+require "support/features/clearance_helpers"
+
+RSpec.feature "Visitor resets password" do
+  before { ActionMailer::Base.deliveries.clear }
+
+  around do |example|
+    original_adapter = ActiveJob::Base.queue_adapter
+    ActiveJob::Base.queue_adapter = :inline
+    example.run
+    ActiveJob::Base.queue_adapter = original_adapter
+  end
+
+  scenario "by navigating to the page" do
+    visit sign_in_path
+
+    click_link I18n.t("sessions.form.forgot_password")
+
+    expect(current_path).to eq new_password_path
+  end
+
+  scenario "with valid email" do
+    user = user_with_reset_password
+
+    expect_page_to_display_change_password_message
+    expect_reset_notification_to_be_sent_to user
+  end
+
+  scenario "with non-user account" do
+    reset_password_for "unknown.email@example.com"
+
+    expect_page_to_display_change_password_message
+    expect_mailer_to_have_no_deliveries
+  end
+
+  private
+
+  def expect_reset_notification_to_be_sent_to(user)
+    expect(user.confirmation_token).not_to be_blank
+    expect_mailer_to_have_delivery(
+      user.email,
+      "password",
+      user.confirmation_token
+    )
+  end
+
+  def expect_page_to_display_change_password_message
+    expect(page).to have_content I18n.t("passwords.create.description")
+  end
+
+  def expect_mailer_to_have_delivery(recipient, subject, body)
+    expect(ActionMailer::Base.deliveries).not_to be_empty
+
+    message = ActionMailer::Base.deliveries.any? do |email|
+      email.to == [recipient] &&
+        email.subject =~ /#{subject}/i &&
+        email.html_part.body =~ /#{body}/ &&
+        email.text_part.body =~ /#{body}/
+    end
+
+    expect(message).to be
+  end
+
+  def expect_mailer_to_have_no_deliveries
+    expect(ActionMailer::Base.deliveries).to be_empty
+  end
+end

--- a/spec/features/clearance/visitor_signs_in_spec.rb
+++ b/spec/features/clearance/visitor_signs_in_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+require "support/features/clearance_helpers"
+
+RSpec.feature "Visitor signs in" do
+  scenario "with valid email and password" do
+    create_user "user@example.com", "password"
+    sign_in_with "user@example.com", "password"
+
+    expect_user_to_be_signed_in
+  end
+
+  scenario "with valid mixed-case email and password " do
+    create_user "user.name@example.com", "password"
+    sign_in_with "User.Name@example.com", "password"
+
+    expect_user_to_be_signed_in
+  end
+
+  scenario "tries with invalid password" do
+    create_user "user@example.com", "password"
+    sign_in_with "user@example.com", "wrong_password"
+
+    expect_page_to_display_sign_in_error
+    expect_user_to_be_signed_out
+  end
+
+  scenario "tries with invalid email" do
+    sign_in_with "unknown.email@example.com", "password"
+
+    expect_page_to_display_sign_in_error
+    expect_user_to_be_signed_out
+  end
+
+  private
+
+  def create_user(email, password)
+    FactoryGirl.create(:user, email: email, password: password)
+  end
+
+  def expect_page_to_display_sign_in_error
+    expect(page.body).to include(
+      I18n.t("flashes.failure_after_create", sign_up_path: sign_up_path)
+    )
+  end
+end

--- a/spec/features/clearance/visitor_signs_up_spec.rb
+++ b/spec/features/clearance/visitor_signs_up_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+require "support/features/clearance_helpers"
+
+RSpec.feature "Visitor signs up" do
+  scenario "by navigating to the page" do
+    visit sign_in_path
+
+    click_link I18n.t("sessions.form.sign_up")
+
+    expect(current_path).to eq sign_up_path
+  end
+
+  scenario "with valid email and password" do
+    sign_up_with "valid@example.com", "password"
+
+    expect_user_to_be_signed_in
+  end
+
+  scenario "tries with invalid email" do
+    sign_up_with "invalid_email", "password"
+
+    expect_user_to_be_signed_out
+  end
+
+  scenario "tries with blank password" do
+    sign_up_with "valid@example.com", ""
+
+    expect_user_to_be_signed_out
+  end
+end

--- a/spec/features/clearance/visitor_updates_password_spec.rb
+++ b/spec/features/clearance/visitor_updates_password_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+require "support/features/clearance_helpers"
+
+RSpec.feature "Visitor updates password" do
+  scenario "with valid password" do
+    user = user_with_reset_password
+    update_password user, "newpassword"
+
+    expect_user_to_be_signed_in
+  end
+
+  scenario "signs in with new password" do
+    user = user_with_reset_password
+    update_password user, "newpassword"
+    sign_out
+    sign_in_with user.email, "newpassword"
+
+    expect_user_to_be_signed_in
+  end
+
+  scenario "tries with a blank password" do
+    user = user_with_reset_password
+    visit_password_reset_page_for user
+    change_password_to ""
+
+    expect(page).to have_content I18n.t("flashes.failure_after_update")
+    expect_user_to_be_signed_out
+  end
+
+  private
+
+  def update_password(user, password)
+    visit_password_reset_page_for user
+    change_password_to password
+  end
+
+  def visit_password_reset_page_for(user)
+    visit edit_user_password_path(
+      user_id: user,
+      token: user.confirmation_token
+    )
+  end
+
+  def change_password_to(password)
+    fill_in "password_reset_password", with: password
+    click_button I18n.t("helpers.submit.password_reset.submit")
+  end
+end

--- a/spec/support/clearance.rb
+++ b/spec/support/clearance.rb
@@ -1,0 +1,1 @@
+require "clearance/rspec"

--- a/spec/support/features/clearance_helpers.rb
+++ b/spec/support/features/clearance_helpers.rb
@@ -1,0 +1,52 @@
+module Features
+  module ClearanceHelpers
+    def reset_password_for(email)
+      visit new_password_path
+      fill_in "password_email", with: email
+      click_button I18n.t("helpers.submit.password.submit")
+    end
+
+    def sign_in
+      password = "password"
+      user = FactoryGirl.create(:user, password: password)
+      sign_in_with user.email, password
+    end
+
+    def sign_in_with(email, password)
+      visit sign_in_path
+      fill_in "session_email", with: email
+      fill_in "session_password", with: password
+      click_button I18n.t("helpers.submit.session.submit")
+    end
+
+    def sign_out
+      click_button I18n.t("layouts.application.sign_out")
+    end
+
+    def sign_up_with(email, password)
+      visit sign_up_path
+      fill_in "user_email", with: email
+      fill_in "user_password", with: password
+      click_button I18n.t("helpers.submit.user.create")
+    end
+
+    def expect_user_to_be_signed_in
+      visit root_path
+      expect(page).to have_button I18n.t("layouts.application.sign_out")
+    end
+
+    def expect_user_to_be_signed_out
+      expect(page).to have_content I18n.t("layouts.application.sign_in")
+    end
+
+    def user_with_reset_password
+      user = FactoryGirl.create(:user)
+      reset_password_for user.email
+      user.reload
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include Features::ClearanceHelpers, type: :feature
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/wLZELtRR)
This branch uses the [Clearance gem](https://github.com/thoughtbot/clearance) to add a user model and implement sign up, sign in, and sign out for a user.

Future tasks:
1. Add name and admin boolean attributes to user
2. Adjust sign in so that user only have to sign in when requesting a book or completing an action (paying fines, updating profile, etc). Browsing can be done without being signed in. 