### PR TITLE
Require sign in for admin routes

### DIFF
--- a/app/controllers/admin/books_controller.rb
+++ b/app/controllers/admin/books_controller.rb
@@ -1,5 +1,5 @@
 class Admin::BooksController < ApplicationController
-  before_action :require_admin
+  before_action :require_login, :require_admin
 
   def index
     @books = Book.all

--- a/spec/features/user_visits_admin_page_before_sign_in_spec.rb
+++ b/spec/features/user_visits_admin_page_before_sign_in_spec.rb
@@ -1,0 +1,9 @@
+require "rails_helper"
+
+feature "User visits /admin/books url without first signing in" do
+  scenario "redirected to sign in page" do
+    visit admin_books_path
+
+    expect(page).to have_css('h2', text: t('layouts.application.sign_in'))
+  end
+end


### PR DESCRIPTION
If a user goes directly to `/admin/books` when not signed in, they will be redirected to the sign in page. This prevents an error from being displayed on the page as the current user is null.

Update: This branch now uses `Clearance's` built-in `:require_login` method as opposed to a custom `:require_sign_in`. 