### PR TITLE
Fines for overdue books display on user profile

### DIFF
--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -1,5 +1,6 @@
 class Checkout < ApplicationRecord
   CHECKOUT_PERIOD_IN_DAYS = 14
+  FINE_AMOUNT_PER_DAY_IN_CENTS = 0.10
 
   belongs_to :user
   belongs_to :book
@@ -9,5 +10,12 @@ class Checkout < ApplicationRecord
 
   def due_date
     self.created_at + CHECKOUT_PERIOD_IN_DAYS.days
+  end
+
+  def fine
+    days_overdue = (Time.zone.now - self.due_date).to_i/1.day
+    if days_overdue > 0
+      fine = FINE_AMOUNT_PER_DAY_IN_CENTS * days_overdue
+    end
   end
 end

--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -13,9 +13,22 @@ class Checkout < ApplicationRecord
   end
 
   def fine
-    days_overdue = (Time.zone.now - self.due_date).to_i/1.day
-    if days_overdue > 0
+    number_of_days_overdue = days_overdue
+    if overdue?
       fine = FINE_AMOUNT_PER_DAY_IN_CENTS * days_overdue
+    else
+      fine = 0
     end
+  end
+
+  def overdue?
+    number_of_days_overdue = days_overdue
+    number_of_days_overdue > 0 ? true : false
+  end
+
+  private
+
+  def days_overdue
+    (Time.zone.now - due_date).to_i/1.day
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,9 @@ class User < ApplicationRecord
   has_many :books, through: :checkouts
 
   validates :name, presence: true
+
+  def total_fines
+    total = checkouts.inject(0) { |total, checkout| total + checkout.fine }
+    total = sprintf('%.2f', total)
+  end
 end

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -7,7 +7,7 @@
       <td><%= t('.author') %></td>
       <td><%= t('.checkout_date') %></td>
       <td><%= t('.due_date') %></td>
-      <td>Fines</td>
+      <td><%= t('.fines') %></td>
       <td></td>
     </tr>
   </thead>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -7,6 +7,7 @@
       <td><%= t('.author') %></td>
       <td><%= t('.checkout_date') %></td>
       <td><%= t('.due_date') %></td>
+      <td>Fines</td>
       <td></td>
     </tr>
   </thead>
@@ -17,6 +18,7 @@
         <td><%= checkout.book.author %></td>
         <td><%= l checkout.created_at, format: :date %></td>
         <td><%= l checkout.due_date, format: :date %></td>
+        <td><%= number_to_currency(checkout.fine) %></td>
         <td><%= link_to t('.return_link'), book_checkout_path(checkout.book, current_user), method: :delete %></td>
       </tr>
     <% end %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -7,7 +7,7 @@
       <td><%= t('.author') %></td>
       <td><%= t('.checkout_date') %></td>
       <td><%= t('.due_date') %></td>
-      <td><%= t('.fines') %></td>
+      <td><%= t('.fine') %></td>
       <td></td>
     </tr>
   </thead>
@@ -18,9 +18,11 @@
         <td><%= checkout.book.author %></td>
         <td><%= l checkout.created_at, format: :date %></td>
         <td><%= l checkout.due_date, format: :date %></td>
-        <td><%= number_to_currency(checkout.fine) %></td>
+        <td class='fine'><%= number_to_currency(checkout.fine) if checkout.overdue? %></td>
         <td><%= link_to t('.return_link'), book_checkout_path(checkout.book, current_user), method: :delete %></td>
       </tr>
     <% end %>
   </tbody>
 </table>
+
+<p class='total_fines'>Total Fines Owed: <%= number_to_currency(current_user.total_fines) %></p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,6 +31,7 @@ en:
       author: Author
       checkout_date: Checkout Date
       due_date: Due Date
+      fines: Fines
       header: Your Books
       title: Title
       return_link: Return

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -31,7 +31,8 @@ en:
       author: Author
       checkout_date: Checkout Date
       due_date: Due Date
-      fines: Fines
+      fine: Fine
+      fine_total: Total Fines Owed
       header: Your Books
       title: Title
       return_link: Return

--- a/spec/features/user_returns_checked_out_book_spec.rb
+++ b/spec/features/user_returns_checked_out_book_spec.rb
@@ -15,7 +15,7 @@ feature 'User returns only books she borrowed from the library' do
 
     click_on t('books.index.check_out_link')
     visit profile_path(as: patron_2)
-    expect(page).to have_css('ul.checkouts li', text: book_2.title)
+    expect(page).to have_css('table.checkouts td', text: book_2.title)
 
     click_on t('profiles.show.return_link')
 

--- a/spec/features/user_sees_fine_amounts_spec.rb
+++ b/spec/features/user_sees_fine_amounts_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+require 'date'
+
+feature 'User sees fine amounts for overdue books' do
+  scenario 'sucessfully' do
+    patron = create(:patron)
+    book = create(:book)
+    checkout = create(:checkout, user: patron, book: book)
+    visit profile_path(as: patron)
+    
+    date_when_book_is_one_day_overdue = DateTime.now + (Checkout::CHECKOUT_PERIOD_IN_DAYS + 1).days
+    Timecop.travel(date_when_book_is_one_day_overdue) do
+      visit profile_path(as: patron)
+    end
+
+    expect(page).to have_content('$0.10')
+    expect(page).to have_css('td', text: 'Fine')
+  end
+end

--- a/spec/features/user_sees_fine_amounts_spec.rb
+++ b/spec/features/user_sees_fine_amounts_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 require 'date'
 
-feature 'User sees fine amounts for overdue books' do
+feature 'User sees fine amounts for individual overdue books and the total fines owed for all books' do
   scenario 'sucessfully' do
     patron = create(:patron)
     book = create(:book)
@@ -12,8 +12,26 @@ feature 'User sees fine amounts for overdue books' do
     Timecop.travel(date_when_book_is_one_day_overdue) do
       visit profile_path(as: patron)
     end
+    expect(page).to have_column_header(t('profiles.show.fine'))
+    expect(page).to have_fine_on_a_single_book_of('$0.10')
+    expect(page).to have_content(t('profiles.show.fine_total'))
+    expect(page).to have_total_fines_of('$0.10')
+    expect(page).to not_have_any_fines_of_zero_dollars
+  end
 
-    expect(page).to have_content('$0.10')
-    expect(page).to have_css('td', text: t('profiles.show.fines'))
+  def have_column_header(header_title)
+    have_css('table.checkouts td', text: header_title)
+  end
+
+  def have_fine_on_a_single_book_of(dollar_amount)
+    have_css('td.fine', text: dollar_amount)
+  end
+
+  def have_total_fines_of(dollar_amount)
+    have_css('p.total_fines', text: dollar_amount)
+  end
+
+  def not_have_any_fines_of_zero_dollars
+    have_no_content('$0.00')
   end
 end

--- a/spec/features/user_sees_fine_amounts_spec.rb
+++ b/spec/features/user_sees_fine_amounts_spec.rb
@@ -7,13 +7,13 @@ feature 'User sees fine amounts for overdue books' do
     book = create(:book)
     checkout = create(:checkout, user: patron, book: book)
     visit profile_path(as: patron)
-    
+
     date_when_book_is_one_day_overdue = DateTime.now + (Checkout::CHECKOUT_PERIOD_IN_DAYS + 1).days
     Timecop.travel(date_when_book_is_one_day_overdue) do
       visit profile_path(as: patron)
     end
 
     expect(page).to have_content('$0.10')
-    expect(page).to have_css('td', text: 'Fine')
+    expect(page).to have_css('td', text: t('profiles.show.fines'))
   end
 end

--- a/spec/features/user_visits_profile_spec.rb
+++ b/spec/features/user_visits_profile_spec.rb
@@ -10,6 +10,6 @@ feature 'User views profile page' do
     visit profile_path(patron)
 
     expect(page).to have_css('.checkouts-header', text: t('profiles.show.header'))
-    expect(page).to have_css('ul.checkouts li', text: book.title)
+    expect(page).to have_css('table.checkouts td', text: book.title)
   end
 end


### PR DESCRIPTION
A fine of 10 cents per day is now applied to books that are overdue. Use's can see the fine amounts for individual overdue books and the total fine owed across all books in their user profiles. 

![screen shot 2017-04-17 at 5 46 52 pm](https://cloud.githubusercontent.com/assets/9501674/25106116/e2b9a846-2395-11e7-87cb-bdd56594d680.png)

