### PR TITLE
Allow users to search for a specific book

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -5,5 +5,11 @@ class BooksController < ApplicationController
     @books = Book.all
     @available_books = @books.available
     @unavailable_books = @books.unavailable
+
+    if params[:search]
+      @books = Book.search(params[:search])
+    else
+      @books = Book.all
+    end
   end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -18,4 +18,8 @@ class Book < ApplicationRecord
        WHERE open_checkouts.id IS NULL"
     )
   end
+
+  def self.search(search)
+    where("author ILIKE ? OR title ILIKE ?", "%#{search}%", "%#{search}%")
+  end
 end

--- a/app/views/books/_books_search.html.erb
+++ b/app/views/books/_books_search.html.erb
@@ -1,0 +1,23 @@
+<%= form_tag(books_path, method: :get, id: 'search_form') do %>
+  <%= text_field_tag :search, params[:search], placeholder: t('books.search.placeholder') %>
+  <%= submit_tag t('books.search.submit'), name: nil %>
+<% end %>
+
+<%= link_to t('books.search.reset'), books_path %>
+
+<% if params[:search] %>
+  <h3> Search Results for <%= params[:search] %> </h3>
+  <ul class="search_results">
+    <% @books.each do |book| %>
+      <li>
+        <%= book.title %>,
+        <%= book.author %>
+        <%= link_to t('books.index.check_out_link'), book_checkouts_path(book, current_user), method: :post %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
+
+<% if @books.blank? %>
+  <h4> <% t('books.search.no_results', param: params[:search]) %>.</h4>
+<% end %>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,5 +1,7 @@
 <h1 class="page-title"><%= t('.header') %></h1>
 
+<%= render "books_search" %>
+
 <h3> Available Books </h3>
 <ul class="books available">
   <% @available_books.each do |book| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -25,6 +25,11 @@ en:
     index:
       check_out_link: Check out
       header: Library Catalog
+    search:
+      no_results: There are no books containing the term %{param}
+      placeholder: Search by book or by author
+      reset: Clear search
+      submit: Search
 
   checkouts:
     create:

--- a/spec/features/user_searches_for_book_spec.rb
+++ b/spec/features/user_searches_for_book_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+feature 'User searches for a specific book' do
+  scenario 'successfully' do
+    searched_book = create(:book, title: 'The Giver')
+    other_book = create(:book, title: 'Of Mice and Men')
+    visit books_path
+
+    fill_in 'search', with: searched_book.title
+    click_on t('books.search.submit')
+
+    expect(page).to have_results(searched_book.title)
+    expect(page).not_to have_results(other_book.title)
+  end
+
+  def have_results(title)
+    have_css('ul.search_results li', text: title)
+  end
+end


### PR DESCRIPTION
This branch adds a search bar to `books_path`. In addition to seeing the list of available & unavailable books and checking out any book that is available, users can now search for a specific book. Search results will be returned at the top of the page. A user can click the `clear search` link to start a new search and remove prior results from the screen. Search supports case-insensitive inputs as well as partial search. 